### PR TITLE
Use os package to handle the PATH environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# swap
+.sw[a-p]
+.*.sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+# auto-generated tag files
+tags
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # pls
 
-pls or _"path ls"_ is a *Windows* CLI utility to make viewing the system PATH easier.
+pls or _"path ls"_ is a CLI utility to make viewing the system PATH easier.
 
-There is already a command to view the entire list of environment variables: "SET"
+In Windows, there is already a command to view the entire list of environment variables: "SET"
 However, `SET` is intended to be used primarily to manipulate or display ALL environment variables via cmd.exe, instead of the System PATH specifically. Additionally, it does not display each individual path in the combined PATH on a new line, making it difficult to find something specific.
 
 ## Getting Started
 
+### Windows
 1. Clone or download the repository: `git clone https://github.com/diamonddelt/pls.git`
 2. Copy the *pls.exe* executable into your System32 directory `C:\Windows\System32`
 3. In a new terminal or CMD shell, simply type `pls`
 
 ### Prerequisites
 
+#### Windows
 There are no prerequisites if you are using the provided .exe.
 
 However, if you'd like to compile the code yourself, you will need a current version of Go installed and configured to run `go build`.

--- a/src/pls.go
+++ b/src/pls.go
@@ -2,20 +2,12 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os/exec"
 	"strings"
+	"os"
 )
 
 func main() {
-	cmd := exec.Command("cmd", "/C", "echo", "%PATH%")
-	raw, err := cmd.Output()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	paths := strings.Split(string(raw), ";")
-	for _, v := range paths {
+	for _, v := range strings.Split(os.Getenv("PATH"), ";") {
 		fmt.Println(v)
 	}
 }


### PR DESCRIPTION
Instead of relying on running a command and checking to see if it works or not, we should use the OS package that's built into Go. Doing this will also make it platform agnostic.

Also added a .gitignore